### PR TITLE
Add openSUSE Leap 15.3 for vargrant operating system.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,6 +1,6 @@
 Vagrant.configure("2") do |config|
     # This will be applied to every vagrant file that comes after it
-    config.vm.box = "opensuse/Leap-15.2.x86_64"
+    config.vm.box = "opensuse/Leap-15.3.x86_64"
     # K8s Node
     config.vm.define "rke" do |k8s_node|
       k8s_node.vm.provision "shell", path: "node_script.sh"

--- a/node_script.sh
+++ b/node_script.sh
@@ -12,14 +12,21 @@ echo -e "iamadmin\niamadmin" | passwd root >/dev/null 2>&1
 
 # Commands for all K8s nodes
 # Add Docker GPG key, Docker Repo, install Docker and enable services
+# For openSUSE Leap 15.3 need to add kernel-default-extra for the overlay and
+# br_netfilter kernel modules
+# Also add chrony for time sync
 # Add repo and Install packages
 sudo zypper --non-interactive update
-sudo zypper --non-interactive install docker
+sudo zypper --non-interactive install docker kernel-default-extra chrony
 
 # Start and enable Services
+sudo systemctl enable chronyd
+sudo systemctl start chronyd
 sudo systemctl daemon-reload 
 sudo systemctl enable docker
 sudo systemctl start docker
+# Set your timezone if required (optional) for example US Central time
+# sudo timedatectl set-timezone America/Chicago
 
 #Confirm that docker group has been created on system
 sudo groupadd docker


### PR DESCRIPTION
Hi, this pull request is to add openSUSE Leap 15.3 as the target operating system as openSUSE Leap 15.2 is almost end of life. Also add kernel-default-extra as this containes the two additional kernel modules now. I also added chrony for time syncing but could be considered optional along with setting the timezone.